### PR TITLE
Add SSL with Let's Encrypt and Certbot

### DIFF
--- a/.github/workflows/certbot_renew.yml
+++ b/.github/workflows/certbot_renew.yml
@@ -1,0 +1,20 @@
+name: Renew SSL certificate
+
+on:
+  schedule:
+    - cron: '30 1 15 * *'
+
+jobs:
+  renew_ssl:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run playbook on server to renew SSL certificate
+        uses: dawidd6/action-ansible-playbook@v2
+        with:
+          playbook: certbot_renew.yml
+          directory: ./infra/ansible
+          key: ${{ secrets.APP_SERVER_SSH_PRIVATE_KEY }}
+          inventory: |
+            [all]
+            ${{ vars.APP_SERVER_HOSTNAME }} ansible_connection=ssh ansible_user=app_server_user
+          requirements: galaxy-requirements.yml

--- a/infra/ansible/certbot_renew.yml
+++ b/infra/ansible/certbot_renew.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  become: true
+  tasks:
+    - name: Renew Let's Encrypt SSL cert with Certbot
+      shell: docker-compose run --rm certbot renew
+      args:
+        chdir: /app

--- a/infra/ansible/deploy.yml
+++ b/infra/ansible/deploy.yml
@@ -1,3 +1,4 @@
+---
 - hosts: all
   become: true
   environment:
@@ -5,9 +6,6 @@
     AZ_SP_PW: "{{ AZ_SP_PW }}"
     AZ_SP_TENANT: "{{ AZ_SP_TENANT }}"
     AZ_VAULT: "{{ AZ_VAULT }}"
-
-  # roles:
-  #   - app-server
 
   tasks:
     - name: Upload files to /app
@@ -18,7 +16,7 @@
         - ../backend.template.env
         - ../docker-compose.build.yml
         - ../docker-compose.yml
-        - ../nginx.conf
+        - ../nginx
 
     - name: Generate env files
       script: ./generate_env.sh
@@ -32,11 +30,37 @@
       shell: az acr login --name threesgame
 
     - name: Pull latest container images
-      shell: env $(cat backend.env) docker-compose pull
+      shell: docker-compose pull
       args:
         chdir: /app
 
     - name: Restart containers
-      shell: env $(cat backend.env) docker-compose up -d --remove-orphans
+      shell: docker-compose up -d --remove-orphans
       args:
         chdir: /app
+
+    - name: Reload test-nginx config
+      include_role:
+        name: reload-nginx
+      vars:
+        nginx_service_name: test-nginx
+
+    - name: Validate test-nginx (local) is reachable
+      uri:
+        url: http://localhost:9980
+        follow_redirects: none
+        status_code: [301]
+
+    - name: Reload real nginx config
+      include_role:
+        name: reload-nginx
+      vars:
+        nginx_service_name: nginx
+
+    - name: Validate website is reachable (HTTP)
+      uri:
+        url: http://{{ domain }}
+
+    - name: Validate website is reachable (HTTPS)
+      uri:
+        url: https://{{ domain }}

--- a/infra/ansible/group_vars/all/main.yml
+++ b/infra/ansible/group_vars/all/main.yml
@@ -1,0 +1,1 @@
+domain: threes-game.eastus.cloudapp.azure.com

--- a/infra/ansible/roles/reload-nginx/tasks/main.yml
+++ b/infra/ansible/roles/reload-nginx/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- name: Try to reload {{ nginx_service_name }}
+  shell: docker-compose exec {{ nginx_service_name }} nginx -s reload
+  args:
+    chdir: /app
+  register: test_nginx_reload_output
+  retries: 5
+  delay: 5
+
+- name: Check if {{ nginx_service_name }} is up
+  shell: docker ps -q --no-trunc | grep $(docker-compose ps -q {{ nginx_service_name }})
+  args:
+    chdir: /app
+  register: check_test_nginx_output
+
+- set_fact:
+    is_test_nginx_container_up: "{{ check_test_nginx_output.stdout != '' }}"
+    test_nginx_reload_ok: "{{ test_nginx_reload_output.stderr_lines | length == 1 }}"
+
+- name: Show logs from {{ nginx_service_name }} if not up
+  when: not is_test_nginx_container_up
+  shell: sudo docker-compose logs --tail 100 {{ nginx_service_name }}
+  args:
+    chdir: /app
+  register: test_nginx_logs
+
+- debug: var=test_nginx_logs.stdout
+  when: not is_test_nginx_container_up
+
+- debug: var=test_nginx_reload_output
+  when: not test_nginx_reload_ok
+
+- name: Ensure that {{ nginx_service_name }} is up and no error from reload
+  assert:
+    that:
+      - is_test_nginx_container_up
+      - test_nginx_reload_ok

--- a/infra/ansible/server_setup.yml
+++ b/infra/ansible/server_setup.yml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - app-server

--- a/infra/ansible/validate_nginx.yml
+++ b/infra/ansible/validate_nginx.yml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - validate-nginx-local

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,19 +1,6 @@
 version: '3.7'
 
 services:
-  nginx:
-    image: nginx:latest
-    restart: always
-    depends_on:
-      - backend
-      - frontend-bundle
-    ports:
-      - 80:80
-      - 443:443
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./frontend-www:/var/www:ro
-
   frontend-bundle:
     extends:
       file: docker-compose.build.yml
@@ -33,6 +20,38 @@ services:
       PORT: 80
     depends_on:
       - db
+
+  nginx:
+    image: nginx:latest
+    restart: always
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - ./frontend-www:/var/www/app:ro
+      - ./nginx/conf.d:/etc/nginx/conf.d/:ro
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./certbot/www:/var/www/certbot/:ro
+      - ./certbot/conf/:/etc/nginx/ssl/:ro
+
+  test-nginx:
+    image: nginx:latest
+    restart: always
+    ports:
+      - 9980:80
+      - 9443:443
+    volumes:
+      - ./frontend-www:/var/www/app:ro
+      - ./nginx/conf.d:/etc/nginx/conf.d/:ro
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./certbot/www:/var/www/certbot/:ro
+      - ./certbot/conf/:/etc/nginx/ssl/:ro
+
+  certbot:
+    image: certbot/certbot:latest
+    volumes:
+      - ./certbot/www/:/var/www/certbot/:rw
+      - ./certbot/conf/:/etc/letsencrypt/:rw
 
   db:
     image: mongo

--- a/infra/nginx/conf.d/default.conf
+++ b/infra/nginx/conf.d/default.conf
@@ -1,19 +1,38 @@
-worker_processes auto;
-
-events {
-  worker_connections 1024;
-}
-
 http {
   server_tokens off;
-  upstream app-backend {
+  upstream backend {
     ip_hash;
     server backend:80;
   }
+
   server {
     listen 80;
+    listen [::]:80;
+
+    server_name threes-game.eastus.cloudapp.azure.com;
+    server_tokens off;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+  }
+
+  server {
+    listen 443 default_server ssl;
+    listen [::]:443 ssl http2;
+
+    server_name threes-game.eastus.cloudapp.azure.com;
+
+    ssl_certificate /etc/nginx/ssl/live/threes-game.eastus.cloudapp.azure.com/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/live/threes-game.eastus.cloudapp.azure.com/privkey.pem;
 
     location /api {
+      resolver 127.0.0.11;
+      proxy_ssl_server_name on;
       rewrite ^/api/?(.*)$ /$1 break;
 
       proxy_set_header Upgrade $http_upgrade;
@@ -25,12 +44,12 @@ http {
       proxy_set_header X-Proxy nginx;
 
       proxy_http_version 1.1;
-      proxy_pass http://app-backend;
+      proxy_pass http://backend;
       proxy_cache_bypass $http_upgrade;
     }
 
     location / {
-      root /var/www;
+      root /var/www/app;
       try_files $uri /index.html
       index index.html;
 

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -1,0 +1,10 @@
+# Note: Changes to this file will only be reflected in nginx container when it is restarted
+# Most of the config is defined in conf.d/default.conf
+
+worker_processes auto;
+
+events {
+  worker_connections 1024;
+}
+
+include /etc/nginx/conf.d/*;


### PR DESCRIPTION
Closes #16 and closes #15 

* Add SSL on nginx webserver
* Restructure the deployment. Add a test-nginx instance to ensure config changes don't break anything
* Scheduled GH Action to renew SSL cert